### PR TITLE
修复专辑封面搜索窗口更新bug

### DIFF
--- a/DynamicLyrics/LyricX/Albumfiller.h
+++ b/DynamicLyrics/LyricX/Albumfiller.h
@@ -20,6 +20,7 @@
     IBOutlet NSCollectionView *collectionView;
 }
 
+-(void)SearchArtwork;
 
 -(IBAction)ChangeAlbum:(id)sender;
  

--- a/DynamicLyrics/LyricX/Albumfiller.m
+++ b/DynamicLyrics/LyricX/Albumfiller.m
@@ -10,6 +10,7 @@
 
 @interface Albumfiller ()
 
+@property (strong, nonatomic) NSString *searchedAlbum;
 @end
 
 @implementation Albumfiller
@@ -19,7 +20,6 @@
 {
     self = [super initWithWindowNibName:@"Albumfiller"];
     if (self) {    
-        
         
         
         DouBan = [[DouBanAPI alloc]init];
@@ -32,8 +32,9 @@
         [dnc addObserver:self selector:@selector(iTunesPlayerInfo) name:@"com.apple.iTunes.playerInfo" object:nil];
         
         
-        operationQueue = [[NSOperationQueue alloc] init]; 
+        operationQueue = [[NSOperationQueue alloc] init];
         [operationQueue setMaxConcurrentOperationCount:5];
+        self.searchedAlbum = nil;
         [self SearchArtwork];
         
         
@@ -71,6 +72,12 @@
     {
         return;
     }
+	NSString *searchAlbum = [NSString stringWithFormat:@"%@ %@", [[iTunes currentTrack] albumArtist],[[iTunes currentTrack] album]];
+	if ([searchAlbum isEqualToString:self.searchedAlbum]) {
+		NSLog(@"Same album. Ignore action.");
+		return;
+	}
+	NSLog(@"Search album: %@", self.searchedAlbum);
     [DouBan SearchArtwork:[[iTunes currentTrack] album]];
     
     SBElementArray* theArtworks = [[iTunes currentTrack] artworks];
@@ -107,6 +114,7 @@
 
         
     }
+	self.searchedAlbum = searchAlbum;
 }
 
 - (void) iTunesPlayerInfo

--- a/DynamicLyrics/LyricX/LyricX-Info.plist
+++ b/DynamicLyrics/LyricX/LyricX-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.1</string>
 	<key>CFBundleVersion</key>
-	<string>799</string>
+	<string>807</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/DynamicLyrics/LyricX/LyricXAppDelegate.m
+++ b/DynamicLyrics/LyricX/LyricXAppDelegate.m
@@ -57,7 +57,7 @@
         AlbumfillerWindow = [[Albumfiller alloc] init];
     else {
         [AlbumfillerWindow.window makeKeyAndOrderFront:self];
-        
+        [AlbumfillerWindow SearchArtwork];
     }
     
 }


### PR DESCRIPTION
修正了当用户关闭专辑搜索窗口后切换专辑播放, 并再次从菜单打开专辑搜索窗口时不能及时更新当前播放的专辑封面的问题
优化了搜索. 当处于同一专辑时不再重复发出搜索请求
