### PR TITLE
keep the menu bar lyircs alway on the left side

### DIFF
--- a/DynamicLyrics/LyricX.xcodeproj/project.pbxproj
+++ b/DynamicLyrics/LyricX.xcodeproj/project.pbxproj
@@ -51,6 +51,16 @@
 		02BB8A3B159CAA9B001334D7 /* Notification.png in Resources */ = {isa = PBXBuildFile; fileRef = 02BB8A3A159CAA9B001334D7 /* Notification.png */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		EF68C6D6169BF788006B9128 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EF68C6CE169BF788006B9128 /* DynamicLyricsHelper.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 02947A311567622400DA746B;
+			remoteInfo = DynamicLyricsHelper;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		02147719159EC64400B92431 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -149,6 +159,7 @@
 		02BB8A37159CA9E8001334D7 /* Lyrics.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Lyrics.png; sourceTree = "<group>"; };
 		02BB8A3A159CAA9B001334D7 /* Notification.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Notification.png; sourceTree = "<group>"; };
 		02CEF1BC1586FFF200B800A6 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = "zh-Hans"; path = "zh-Hans.lproj/Albumfiller.xib"; sourceTree = "<group>"; };
+		EF68C6CE169BF788006B9128 /* DynamicLyricsHelper.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DynamicLyricsHelper.xcodeproj; path = ../DynamicLyricsHelper/DynamicLyricsHelper.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -242,6 +253,7 @@
 				02710E94152A839F006D4BFF /* LyricX */,
 				02710E8D152A839F006D4BFF /* Frameworks */,
 				02710E8B152A839F006D4BFF /* Products */,
+				EF68C6CE169BF788006B9128 /* DynamicLyricsHelper.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -347,6 +359,14 @@
 			name = UI;
 			sourceTree = "<group>";
 		};
+		EF68C6CF169BF788006B9128 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EF68C6D7169BF788006B9128 /* DynamicLyricsHelper.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -392,12 +412,28 @@
 			mainGroup = 02710E7F152A839F006D4BFF;
 			productRefGroup = 02710E8B152A839F006D4BFF /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = EF68C6CF169BF788006B9128 /* Products */;
+					ProjectRef = EF68C6CE169BF788006B9128 /* DynamicLyricsHelper.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				02710E89152A839F006D4BFF /* DynamicLyrics */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		EF68C6D7169BF788006B9128 /* DynamicLyricsHelper.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = DynamicLyricsHelper.app;
+			remoteRef = EF68C6D6169BF788006B9128 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		02710E88152A839F006D4BFF /* Resources */ = {

--- a/DynamicLyrics/LyricX/LyricX-Info.plist
+++ b/DynamicLyrics/LyricX/LyricX-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.1</string>
 	<key>CFBundleVersion</key>
-	<string>808</string>
+	<string>809</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/DynamicLyrics/LyricX/MenuBarLyrics.m
+++ b/DynamicLyrics/LyricX/MenuBarLyrics.m
@@ -9,6 +9,11 @@
 #import "MenuBarLyrics.h"
 #import "Constants.h"
 
+@interface NSStatusBar (NSStatusBar_Private)
+- (id)_statusItemWithLength:(float)l withPriority:(int)p;
+- (id)_insertStatusItem:(NSStatusItem *)i withPriority:(int)p;
+@end
+
 @implementation MenuBarLyrics
 
 @synthesize  CurrentSongLyrics;
@@ -18,8 +23,12 @@
     if (self) {
         _queue = [[NSOperationQueue alloc] init]; 
         [_queue setMaxConcurrentOperationCount:1];
-        _statusItem = [[[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength] retain];
+        NSStatusBar *bar = [NSStatusBar systemStatusBar];
+        _statusItem = [[bar _statusItemWithLength:0 withPriority:INT_MIN] retain];
         //[_statusItem setTitle:@"LyricsX!"];
+        [bar removeStatusItem:_statusItem];
+        [bar _insertStatusItem:_statusItem withPriority:INT_MIN];
+        [_statusItem setLength:NSVariableStatusItemLength];
         [_statusItem setImage:[NSImage imageNamed:@"StatusIcon.png"]];
         [_statusItem setHighlightMode:YES];
         [_statusItem setMenu:AppMenu];

--- a/DynamicLyricsHelper/DynamicLyricsHelper.xcodeproj/project.pbxproj
+++ b/DynamicLyricsHelper/DynamicLyricsHelper.xcodeproj/project.pbxproj
@@ -234,14 +234,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = DynamicLyricsHelper/DynamicLyricsHelper.entitlements;
-				CODE_SIGN_IDENTITY = "3rd Party Mac Developer Application: Zhu Zheng";
+				CODE_SIGN_IDENTITY = "";
 				GCC_C_LANGUAGE_STANDARD = c89;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DynamicLyricsHelper/DynamicLyricsHelper-Prefix.pch";
 				INFOPLIST_FILE = "DynamicLyricsHelper/DynamicLyricsHelper-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 				SDKROOT = "";
 				WRAPPER_EXTENSION = app;
 			};
@@ -251,14 +250,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = DynamicLyricsHelper/DynamicLyricsHelper.entitlements;
-				CODE_SIGN_IDENTITY = "3rd Party Mac Developer Application: Zhu Zheng";
+				CODE_SIGN_IDENTITY = "";
 				GCC_C_LANGUAGE_STANDARD = c89;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DynamicLyricsHelper/DynamicLyricsHelper-Prefix.pch";
 				INFOPLIST_FILE = "DynamicLyricsHelper/DynamicLyricsHelper-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 				SDKROOT = "";
 				WRAPPER_EXTENSION = app;
 			};


### PR DESCRIPTION
menu bar lyircs 长度不固定，如果在打开 DynameicLyrics后又有图标出现在 Status Bar
上时，这些图标的位置会随歌词长度变化不断改变位置， 这个 commit 可以保持 menu bar lyircs 一直处于 Status
Bar 的左侧，避免上述情况的出现 :-)
FYI:
http://linfan.info/blog/2012/02/28/cocoa-icon-on-right-side-of-menu-bar/
