### PR TITLE
Fix displaying null when playing music video

### DIFF
--- a/DynamicLyrics/LyricX/MainController.m
+++ b/DynamicLyrics/LyricX/MainController.m
@@ -210,7 +210,11 @@
         NSString *SongTitle = [iTunesCurrentTrack name];
         NSString *SongArtist = [iTunesCurrentTrack artist];
         
-        self.CurrentSongLyrics = [NSString stringWithFormat:@"%@ - %@",SongTitle,SongArtist];
+        if(SongTitle == nil) {
+            self.CurrentSongLyrics = @"";
+        }else{
+            self.CurrentSongLyrics = [NSString stringWithFormat:@"%@ - %@",SongTitle,SongArtist];
+        }
         [nc postNotificationName:@"LyricsChanged" object:self userInfo:[NSDictionary dictionaryWithObject:self.CurrentSongLyrics forKey:@"Lyrics"]];
         
         


### PR DESCRIPTION
Bug 演示： https://www.dropbox.com/s/sqc7j6kzemdd0at/dyn-bug-2.mov

实际上这应该是一个 iTunes 的 Bug ，在 Music Videos 分类下播放的任何 MV ，均不能通过 ScriptingBridge 获取到播放的信息，但如果是在其他的显示模式下播放的 MV （比如这个 MV 属于某张专辑，然后在专辑列表中播放），则无此 bug 。

在播放的时候显示 null 终归是觉得很不爽，所以就给设置成 `@""` 了。
